### PR TITLE
feat(buildkite): add buildkite pipeline

### DIFF
--- a/.buildkite/deploy-unheic.yml
+++ b/.buildkite/deploy-unheic.yml
@@ -1,0 +1,70 @@
+# Deploy pipeline for the unheic service (RIV-1180).
+#
+# Builds the image from the repo-root Dockerfile, pushes it to shared-services
+# ECR, then rolls each environment's ECS service to it in order: development
+# first, staging once development is stable (production later, gated — see
+# RIV-1346). Pulumi (rivettax/rivet infrastructure/workload) seeds the initial
+# task definition; this pipeline owns the live image thereafter (the ECS
+# service ignores taskDefinition drift).
+#
+# The scripts in .buildkite/scripts/ are copies of the rivettax/rivet ones —
+# the shape mirrors that repo's deploy-core.yml, where each step's role ARN is
+# the single place its AWS account ID appears: the build script derives the
+# ECR registry from the assumed role's own identity, and the ecr plugin
+# defaults to that account too.
+#
+# No if_changed filter: the whole repo is the service.
+
+env:
+  AWS_REGION: &aws_region us-west-2
+  ECR_REPO: rivet/unheic
+  IMAGE_CONTEXT: .
+  CONTAINER_NAME: unheic
+  ECS_SERVICE: unheic
+
+agents:
+  queue: "default"
+
+steps:
+  - label: ":docker: Build and push"
+    key: build-and-push
+    command: .buildkite/scripts/image-build-push.sh
+    plugins:
+      - aws-assume-role-with-web-identity#v1.6.0:
+          # PulumiDeployer in rivet-shared-services, which owns the ECR
+          # registry every environment pulls from.
+          role-arn: arn:aws:iam::656326302886:role/PulumiDeployer
+          region: *aws_region
+      # No account-ids: defaults to the account of the current credentials —
+      # the shared-services role assumed above.
+      - ecr#v2.12.0:
+          login: true
+          region: *aws_region
+
+  - label: ":ecs: Deploy to development"
+    key: deploy-development
+    depends_on: build-and-push
+    env:
+      ECS_CLUSTER: rivet-development
+      TASK_FAMILY: rivet-development-unheic
+    command: .buildkite/scripts/ecs-deploy.sh
+    plugins:
+      - aws-assume-role-with-web-identity#v1.6.0:
+          # PulumiDeployer in rivet-development.
+          role-arn: arn:aws:iam::951013218268:role/PulumiDeployer
+          region: *aws_region
+
+  - label: ":ecs: Deploy to staging"
+    key: deploy-staging
+    # Progressive rollout: staging only rolls once development is stable
+    # (services-stable in the dev step), so a bad image stops in dev.
+    depends_on: deploy-development
+    env:
+      ECS_CLUSTER: rivet-staging
+      TASK_FAMILY: rivet-staging-unheic
+    command: .buildkite/scripts/ecs-deploy.sh
+    plugins:
+      - aws-assume-role-with-web-identity#v1.6.0:
+          # PulumiDeployer in rivet-staging.
+          role-arn: arn:aws:iam::696000197535:role/PulumiDeployer
+          region: *aws_region

--- a/.buildkite/scripts/ecs-deploy.sh
+++ b/.buildkite/scripts/ecs-deploy.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hosted agents run jobs in a PTY without `less`, so any aws command whose
+# stdout isn't captured would die with "Unable to redirect output to pager"
+# (exit 253) — after the API call succeeds but before the wait/verify below.
+export AWS_PAGER=""
+
+# Rolls the ECS service $ECS_CLUSTER/$ECS_SERVICE to the image published by
+# the build step (meta-data key `image`): registers a new revision of
+# $TASK_FAMILY with $CONTAINER_NAME's image swapped, points the service at it,
+# and waits for the rollout to stabilize. The ECS deployment circuit breaker
+# rolls back automatically if the new tasks never go healthy.
+
+image="$(buildkite-agent meta-data get image)"
+
+task_def="$(aws ecs describe-task-definition \
+  --task-definition "${TASK_FAMILY}" \
+  --query taskDefinition --output json)"
+
+# A container-name mismatch would make the image swap below a silent no-op —
+# the old image would redeploy and report success — so fail fast instead.
+if ! echo "${task_def}" | jq -e --arg name "${CONTAINER_NAME}" \
+  '.containerDefinitions | any(.name == $name)' >/dev/null; then
+  echo "container ${CONTAINER_NAME} not found in task definition ${TASK_FAMILY}" >&2
+  exit 1
+fi
+
+# Strip the read-only fields describe returns; register-task-definition
+# rejects them.
+new_task_def="$(echo "${task_def}" | jq \
+  --arg img "${image}" \
+  --arg name "${CONTAINER_NAME}" \
+  '.containerDefinitions |= map(if .name == $name then .image = $img else . end)
+   | del(.taskDefinitionArn, .revision, .status, .requiresAttributes,
+         .compatibilities, .registeredAt, .registeredBy)')"
+
+new_arn="$(aws ecs register-task-definition \
+  --cli-input-json "${new_task_def}" \
+  --query taskDefinition.taskDefinitionArn --output text)"
+
+aws ecs update-service \
+  --cluster "${ECS_CLUSTER}" --service "${ECS_SERVICE}" \
+  --task-definition "${new_arn}"
+
+aws ecs wait services-stable \
+  --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}"
+
+# services-stable also reports success when the deployment circuit breaker
+# rolled back to the previous revision — the service is stable, just not on
+# our image. Verify the primary deployment runs the new revision so a
+# rollback fails this step (and blocks the staging stage in deploy-core).
+primary="$(aws ecs describe-services \
+  --cluster "${ECS_CLUSTER}" --services "${ECS_SERVICE}" \
+  --query 'services[0].deployments[?status==`PRIMARY`].taskDefinition | [0]' \
+  --output text)"
+if [[ "${primary}" != "${new_arn}" ]]; then
+  echo "deployment rolled back: ${ECS_SERVICE} is running ${primary}, expected ${new_arn}" >&2
+  exit 1
+fi
+
+echo "Deployed ${image} to ${ECS_CLUSTER}/${ECS_SERVICE}"

--- a/.buildkite/scripts/image-build-push.sh
+++ b/.buildkite/scripts/image-build-push.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Builds the Docker image from $IMAGE_CONTEXT, pushes it to the
+# shared-services ECR repo $ECR_REPO tagged with the commit SHA, and publishes
+# the pushed reference as the `image` meta-data key for the deploy steps.
+#
+# The registry account comes from the credentials the assume-role plugin
+# already established, so the account ID lives in exactly one place per
+# pipeline file: the role ARN.
+
+account_id="$(aws sts get-caller-identity --query Account --output text)"
+image="${account_id}.dkr.ecr.${AWS_REGION}.amazonaws.com/${ECR_REPO}"
+tag="sha-${BUILDKITE_COMMIT}"
+
+# --push makes BuildKit push straight from the builder: hosted agents build
+# via a remote BuildKit driver, so the image never lands in the local daemon
+# and a separate `docker push` would fail with "tag does not exist".
+docker build --push --platform linux/amd64 -t "${image}:${tag}" "${IMAGE_CONTEXT}"
+buildkite-agent meta-data set image "${image}:${tag}"
+echo "Pushed ${image}:${tag}"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> New automated deploys to dev/staging ECS with cross-account IAM roles; mistakes could roll bad images, though progressive rollout and rollback verification limit blast radius.
> 
> **Overview**
> Adds **CI/CD for the unheic service** via a new Buildkite pipeline (`.buildkite/deploy-unheic.yml`) that builds the repo-root Docker image, pushes to shared-services ECR (`rivet/unheic`), then rolls ECS in **development** and **staging** in sequence (staging waits until dev is stable). Production is explicitly deferred (RIV-1346). Each step assumes `PulumiDeployer` in the target AWS account; live image updates are owned by the pipeline while Pulumi seeds the initial task definition.
> 
> Supporting shell scripts mirror the rivettax/rivet deploy pattern: **`image-build-push.sh`** derives the ECR registry from the assumed role, tags with `sha-${BUILDKITE_COMMIT}`, and stores the image URI in Buildkite meta-data; **`ecs-deploy.sh`** registers a new task revision with the container image swapped, updates the service, waits for stability, and **fails if the deployment circuit breaker rolled back** (so a bad image blocks staging).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b19fbfdd21e7489e11412892aa87e9a1aa518ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->